### PR TITLE
Add Dependabot auto-merge workflow; fix macOS CI for Apple Silicon

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,17 @@ jobs:
           - windows-latest
         arch:
           - x64
+        exclude:
+          # macos-latest is Apple Silicon (arm64); x64 is unsupported there.
+          - os: macos-latest
+            arch: x64
+        include:
+          - os: macos-latest
+            arch: aarch64
+            version: '1'
+          - os: macos-latest
+            arch: aarch64
+            version: 'pre'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+# Enables GitHub native auto-merge on Dependabot PRs. Once the required status
+# checks pass, GitHub squash-merges the PR automatically. This relies on branch
+# protection requiring CI checks — without required checks, auto-merge has
+# nothing to wait on and would error with "Pull request is in clean status".
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Merge everything that passes CI. To restrict to patch/minor only, add to
+      # the condition below, e.g.:
+      #   if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Two changes:

1. **Add Dependabot auto-merge** (native, gated on required checks).
2. **Fix macOS CI**: `macos-latest` is now Apple Silicon (arm64), but the matrix requested `x64`, which setup-julia rejects. macOS now runs on `aarch64`.

Branch protection on `main` requires the `Julia 1` ubuntu + windows jobs (prerelease and macOS left non-required).